### PR TITLE
chore: debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for rdebug-ide",
+      "type": "Ruby",
+      "request": "attach",
+      "remoteHost": "127.0.0.1",
+      "remotePort": "1234",
+      "remoteWorkspaceRoot": "${workspaceRoot}"
+    }
+  ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,12 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  # Debuguger
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'ruby-debug-ide', '~> 0.7.3'
+  gem 'debase', '~> 0.2.5.beta2'
+  # End Debuger
+
   gem "faker", require: false
   gem "i18n-tasks", "~> 1.0.12"
   gem "erb-formatter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,9 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.3)
+    debase (0.2.5.beta2)
+      debase-ruby_core_source (>= 0.10.12)
+    debase-ruby_core_source (3.2.0)
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -406,6 +409,8 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-shopify (2.12.0)
       rubocop (~> 1.44)
+    ruby-debug-ide (0.7.3)
+      rake (>= 0.8.1)
     ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
@@ -530,6 +535,7 @@ DEPENDENCIES
   countries
   cssbundling-rails
   database_cleaner
+  debase (~> 0.2.5.beta2)
   debug
   devise
   dotenv-rails
@@ -560,6 +566,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0.0)
   rubocop
   rubocop-shopify
+  ruby-debug-ide (~> 0.7.3)
   selenium-webdriver
   simplecov
   simplecov-cobertura

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3030
+web: eval '$WEB_START_COMMAND'
 prommy-js: yarn build:js --watch
 prommy-css: yarn build:css --watch
 avo-js: cd ./../avo && yarn build:js --watch

--- a/bin/dev
+++ b/bin/dev
@@ -9,7 +9,7 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
-debugger=false
+export WEB_START_COMMAND='bin/rails server -p 3030'
 
 for arg in "$@"; do
   if [ "$arg" = "debugger" ]; then
@@ -18,13 +18,8 @@ for arg in "$@"; do
     echo "Inside VSCode, open the debug panel and run 'Listen for rdebug-ide'."
     echo "=== Waiting listener to attach ==="
     export WEB_START_COMMAND='rdebug-ide --host 0.0.0.0 --port 1234 --dispatcher-port 26162 -- bin/rails server -p 3030'
-    debugger=true
     break
   fi
 done
-
-if ! $debugger; then
-  export WEB_START_COMMAND='bin/rails server -p 3030'
-fi
 
 exec overmind start -f Procfile "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -9,4 +9,22 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
+debugger=false
+
+for arg in "$@"; do
+  if [ "$arg" = "debugger" ]; then
+    echo "=== Starting in debugger mode ==="
+    echo "Make sure you have the VSCode rdbg Ruby Debugger extension installed and configured."
+    echo "Inside VSCode, open the debug panel and run 'Listen for rdebug-ide'."
+    echo "=== Waiting listener to attach ==="
+    export WEB_START_COMMAND='rdebug-ide --host 0.0.0.0 --port 1234 --dispatcher-port 26162 -- bin/rails server -p 3030'
+    debugger=true
+    break
+  fi
+done
+
+if ! $debugger; then
+  export WEB_START_COMMAND='bin/rails server -p 3030'
+fi
+
 exec overmind start -f Procfile "$@"


### PR DESCRIPTION
Usage little demo:

We can start server normally or in debug mode (use "debugger" as argument when calling bin/dev)
When start on debug mode the server only really start listening on VSCode

[debugger.webm](https://user-images.githubusercontent.com/69730720/226101877-3f7b5440-9c43-4669-95ce-8b0341cda77b.webm)
